### PR TITLE
allow autowiring private fields too

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ class RelationalDatabase : Database {}
 
 class DataWriter {
 	@Autowire
-	public Database database; // Automatically injected when class is resolved
+	private Database database; // Automatically injected when class is resolved
 }
 
 void main() {

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -70,7 +70,7 @@ class ExampleClassA {}
 
 class ExampleClassB {
 	@Autowire
-	public ExampleClassA dependency;
+	private ExampleClassA dependency;
 }
 
 dependencies.register!ExampleClassA;
@@ -78,7 +78,7 @@ auto exampleInstance = new ExampleClassB();
 dependencies.autowire(exampleInstance);
 assert(exampleInstance.dependency !is null);
 ```
-At the moment, it is only possible to autowire public members or properties.
+It is possible to autowire public and private members.
 
 Dependencies are automatically autowired when a class is resolved. So when you register ExampleClassB, its member, *dependency*, is automatically autowired:
 ```d

--- a/test/poodinis/autowiretest.d
+++ b/test/poodinis/autowiretest.d
@@ -22,6 +22,7 @@ version(unittest) {
 
 	class ComponentD {
 		public @Autowire InterfaceA componentC = null;
+        private @Autowire InterfaceA privateComponentC = null;
 	}
 
 	class DummyAttribute{};
@@ -86,6 +87,15 @@ version(unittest) {
 		container.autowire!(ComponentD)(componentD);
 		assert(componentD.componentC !is null, "Autowirable dependency failed to autowire");
 	}
+
+    // Test autowiring private members
+    unittest {
+        shared(DependencyContainer) container = new DependencyContainer();
+        container.register!(InterfaceA, ComponentC);
+        auto componentD = new ComponentD();
+        container.autowire!(ComponentD)(componentD);
+        assert(componentD.privateComponentC is componentD.componentC, "Autowire private dependency failed");
+    }
 
 	// Test autowiring will only happen once
 	unittest {


### PR DESCRIPTION
this works using T.tupleof and the helpers in std.traits because using __traits alone forbids access to private fields.