### PR TITLE
Add conditional __compiles check before calling __traits(getOverloads, ...) in AutowiredRegistration.getPreDestructor.

### DIFF
--- a/source/poodinis/autowire.d
+++ b/source/poodinis/autowire.d
@@ -309,12 +309,14 @@ class AutowiredRegistration(RegistrationType : Object) : Registration {
     private void delegate() getPreDestructor(RegistrationType instance) {
         void delegate() preDestructor = null;
         static foreach (memberName; __traits(allMembers, RegistrationType)) {
-            static foreach (overload; __traits(getOverloads, RegistrationType, memberName)) {
-                static if (__traits(compiles, __traits(getProtection, overload))
-                    && __traits(getProtection, overload) == "public"
-                    && isFunction!overload
-                    && hasUDA!(overload, PreDestroy)) {
-                    preDestructor = &__traits(getMember, instance, memberName);
+            static if (__traits(compiles, __traits(getOverloads, RegistrationType, memberName))) {
+                static foreach (overload; __traits(getOverloads, RegistrationType, memberName)) {
+                    static if (__traits(compiles, __traits(getProtection, overload))
+                            && __traits(getProtection, overload) == "public"
+                            && isFunction!overload
+                            && hasUDA!(overload, PreDestroy)) {
+                            preDestructor = &__traits(getMember, instance, memberName);
+                    }
                 }
             }
         }


### PR DESCRIPTION
__traits(getOverloads, ...) can fail with errors like `conflicting symbols found` in certain special cases described in #46.